### PR TITLE
Revert urllib3 upgrade

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,7 +40,7 @@ sniffio==1.3.1
 starlette==0.45.3
 typer==0.15.1
 typing_extensions==4.12.2
-urllib3==2.2.2
+urllib3==2.2.1
 uvicorn==0.34.0
 uvloop==0.21.0
 watchfiles==1.0.4


### PR DESCRIPTION
Bandwidth-sdk requires urllib 2.2.1